### PR TITLE
[codex] improve comment extension core

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,7 +1,7 @@
 {
   "editor.formatOnSave": true,
   "editor.codeActionsOnSave": {
-    "source.organizeImports": true,
-    "source.fixAll": true
+    "source.organizeImports": "explicit",
+    "source.fixAll": "explicit"
   },
 }

--- a/README.md
+++ b/README.md
@@ -30,11 +30,7 @@ npm i @sereneinserenade/tiptap-comment-extension
 
 ```ts
 import StarterKit from "@tiptap/starter-kit";
-import CommentExtension from "@sereneinserenade/tiptap-comment-extension";
-
-/* or
-import { CommentExtension } from "@sereneinserenade/tiptap-comment-extension";
-*/
+import { Comment } from "@sereneinserenade/tiptap-comment-extension";
 
 const extensions = [
   StarterKit,
@@ -42,10 +38,13 @@ const extensions = [
     HTMLAttributes: {
       class: "my-comment",
     },
+    activeClass: "my-comment--active",
+    hoveredClass: "my-comment--hovered",
     onCommentActivated: (commentId) => {
       setActiveCommentId(commentId);
-
-      if (commentId) setTimeout(() => focusCommentWithActiveId(commentId));
+    },
+    onCommentSelectionChange: (commentIds) => {
+      setSelectedCommentIds(commentIds);
     },
   }),
 ];
@@ -62,10 +61,13 @@ Comment.configure({
   HTMLAttributes: {
     class: "my-comment",
   },
+  activeClass: "my-comment--active",
+  hoveredClass: "my-comment--hovered",
   onCommentActivated: (commentId) => {
     setActiveCommentId(commentId);
-
-    if (commentId) setTimeout(() => focusCommentWithActiveId(commentId));
+  },
+  onCommentSelectionChange: (commentIds) => {
+    setSelectedCommentIds(commentIds);
   },
 });
 ```
@@ -74,8 +76,23 @@ Comment.configure({
 
 - `setComment`: Sets the comment for the current selection with the given commentId. <br/>
   Example: `editor.commands.setComment('<a-comment-id>')`
-- `unsetComment`: Unsets the comment for the given commentId. <br/>
-  Example: `editor.commands.unsetComment('<a-comment-id>')`
+- `unsetComment`: Removes the comment mark from the current selection, or from a specific commentId when one is provided. <br/>
+  Example: `editor.commands.unsetComment()` or `editor.commands.unsetComment('<a-comment-id>')`
+- `removeComment`: Removes every range for the given commentId in the document. <br/>
+  Example: `editor.commands.removeComment('<a-comment-id>')`
+- `selectComment`: Selects the first logical range for the given commentId. <br/>
+  Example: `editor.commands.selectComment('<a-comment-id>')`
+- `hoverComment`: Sets or clears the hovered comment id for decoration-driven sidebars. <br/>
+  Example: `editor.commands.hoverComment('<a-comment-id>')`
+
+## Helpers:
+
+- `getCommentRanges(doc, commentId?)`: returns grouped logical ranges for comments, which is useful for building a sidebar without duplicating split inline segments.
+
+## Notes:
+
+- This package is still a lightweight mark-based anchor layer. Comment bodies, replies, resolved state, and persistence should live in your own app state.
+- Overlapping comments are not supported in the current mark-based model.
 
 ## Stargazers
 

--- a/demos/react/src/components/Tiptap.tsx
+++ b/demos/react/src/components/Tiptap.tsx
@@ -79,6 +79,8 @@ const Tiptap = () => {
         HTMLAttributes: {
           class: 'my-comment'
         },
+        activeClass: 'ring-2 ring-blue-400',
+        hoveredClass: 'bg-blue-500/10',
         onCommentActivated: (commentId) => {
           setActiveCommentId(commentId)
 
@@ -120,6 +122,15 @@ const Tiptap = () => {
                     <div
                       key={comment.id}
                       className={`flex flex-col gap-4 p-2 border rounded-lg border-slate-400 ${comment.id === activeCommentId ? 'border-blue-400 border-2' : ''} box-border`}
+                      onClick={() => {
+                        editor.commands.selectComment(comment.id)
+                      }}
+                      onMouseEnter={() => {
+                        editor.commands.hoverComment(comment.id)
+                      }}
+                      onMouseLeave={() => {
+                        editor.commands.hoverComment(null)
+                      }}
                     >
                       <span className='flex items-end gap-2'>
                         <a href='https://github.com/sereneinserenade' className='font-semibold border-b border-blue-200'>

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "build": "npm run clean && npm run build:types && rollup -c",
     "build:types": "tsc --emitDeclarationOnly --declaration --noEmit false --outDir dist",
     "dev": "npm run clean && rollup -c -w",
-    "test": "node --test"
+    "test": "npm run build && node --test"
   },
   "devDependencies": {
     "@rollup/plugin-babel": "^6.0.3",

--- a/src/comment.ts
+++ b/src/comment.ts
@@ -1,6 +1,8 @@
 import { Mark, mergeAttributes } from "@tiptap/core";
-import type { Range } from "@tiptap/core";
-import type { Mark as PMMark } from "@tiptap/pm/model";
+import type { Attributes, Range } from "@tiptap/core";
+import type { Mark as PMMark, Node as PMNode } from "@tiptap/pm/model";
+import { Plugin, PluginKey, TextSelection } from "@tiptap/pm/state";
+import { Decoration, DecorationSet } from "@tiptap/pm/view";
 
 declare module "@tiptap/core" {
   interface Commands<ReturnType> {
@@ -10,34 +12,221 @@ declare module "@tiptap/core" {
        */
       setComment: (commentId: string) => ReturnType;
       /**
-       * Unset a comment (remove)
+       * Unset a comment from the current selection, or remove all comment
+       * ranges for the provided commentId.
        */
-      unsetComment: (commentId: string) => ReturnType;
+      unsetComment: (commentId?: string) => ReturnType;
+      /**
+       * Remove all comment ranges for the given commentId.
+       */
+      removeComment: (commentId: string) => ReturnType;
+      /**
+       * Select the first logical range for the given commentId.
+       */
+      selectComment: (commentId: string) => ReturnType;
+      /**
+       * Mark a comment as hovered for decoration-driven UIs.
+       */
+      hoverComment: (commentId: string | null) => ReturnType;
     };
   }
 }
 
-export interface MarkWithRange {
-  mark: PMMark;
-  range: Range;
+export interface CommentRange extends Range {
+  commentId: string;
+  text: string;
+}
+
+export interface CommentPluginState {
+  activeCommentIds: string[];
+  hoveredCommentId: string | null;
+  decorations: DecorationSet;
+}
+
+interface CommentPluginMeta {
+  hoveredCommentId: string | null;
 }
 
 export interface CommentOptions {
-  HTMLAttributes: Record<string, any>;
-  onCommentActivated: (commentId: string) => void;
+  HTMLAttributes: Attributes;
+  activeClass: string;
+  hoveredClass: string;
+  onCommentActivated: (commentId: string | null) => void;
+  onCommentSelectionChange: (commentIds: string[]) => void;
 }
 
 export interface CommentStorage {
   activeCommentId: string | null;
+  activeCommentIds: string[];
+  hoveredCommentId: string | null;
+}
+
+export const commentPluginKey = new PluginKey<CommentPluginState>("comment");
+
+function areStringArraysEqual(left: string[], right: string[]) {
+  return (
+    left.length === right.length &&
+    left.every((value, index) => value === right[index])
+  );
+}
+
+function getCommentMark(mark: PMMark, commentId?: string) {
+  return (
+    mark.type.name === "comment" &&
+    (commentId === undefined || mark.attrs.commentId === commentId)
+  );
+}
+
+export function getCommentRanges(doc: PMNode, commentId?: string): CommentRange[] {
+  const commentRanges: CommentRange[] = [];
+  let previousRange: CommentRange | null = null;
+
+  doc.descendants((node, pos) => {
+    const commentMark = node.marks.find((mark) => getCommentMark(mark, commentId));
+
+    if (!commentMark) {
+      previousRange = null;
+      return;
+    }
+
+    const range = {
+      commentId: commentMark.attrs.commentId,
+      from: pos,
+      to: pos + node.nodeSize,
+      text: node.textContent,
+    };
+
+    if (
+      previousRange &&
+      previousRange.commentId === range.commentId &&
+      previousRange.to === range.from
+    ) {
+      previousRange.to = range.to;
+      previousRange.text += range.text;
+      return;
+    }
+
+    commentRanges.push(range);
+    previousRange = range;
+  });
+
+  return commentRanges;
+}
+
+function getSelectionCommentIds(
+  doc: PMNode,
+  selectionFrom: number,
+  selectionTo: number,
+  empty: boolean,
+  marks: readonly PMMark[],
+) {
+  if (empty) {
+    return [
+      ...new Set(
+        marks
+          .filter((mark) => getCommentMark(mark))
+          .map((mark) => mark.attrs.commentId as string),
+      ),
+    ];
+  }
+
+  const commentIds = new Set<string>();
+
+  doc.nodesBetween(selectionFrom, selectionTo, (node) => {
+    node.marks.forEach((mark) => {
+      if (!getCommentMark(mark)) {
+        return;
+      }
+
+      commentIds.add(mark.attrs.commentId);
+    });
+  });
+
+  return [...commentIds];
+}
+
+function buildDecorations(
+  doc: PMNode,
+  activeCommentIds: string[],
+  hoveredCommentId: string | null,
+  activeClass: string,
+  hoveredClass: string,
+) {
+  if (!activeClass && !hoveredClass) {
+    return DecorationSet.empty;
+  }
+
+  const decorations = getCommentRanges(doc)
+    .map((range) => {
+      const classNames = [];
+
+      if (activeClass && activeCommentIds.indexOf(range.commentId) >= 0) {
+        classNames.push(activeClass);
+      }
+
+      if (hoveredClass && hoveredCommentId === range.commentId) {
+        classNames.push(hoveredClass);
+      }
+
+      if (!classNames.length) {
+        return null;
+      }
+
+      return Decoration.inline(range.from, range.to, {
+        class: classNames.join(" "),
+      });
+    })
+    .filter(Boolean) as Decoration[];
+
+  return decorations.length ? DecorationSet.create(doc, decorations) : DecorationSet.empty;
+}
+
+function createPluginState(
+  doc: PMNode,
+  activeCommentIds: string[],
+  hoveredCommentId: string | null,
+  activeClass: string,
+  hoveredClass: string,
+): CommentPluginState {
+  return {
+    activeCommentIds,
+    hoveredCommentId,
+    decorations: buildDecorations(
+      doc,
+      activeCommentIds,
+      hoveredCommentId,
+      activeClass,
+      hoveredClass,
+    ),
+  };
+}
+
+function removeCommentRanges(tr: any, commentRanges: CommentRange[], mark: PMMark) {
+  commentRanges.forEach((range) => {
+    tr.removeMark(range.from, range.to, mark);
+  });
 }
 
 export const CommentExtension = Mark.create<CommentOptions, CommentStorage>({
   name: "comment",
 
+  priority: 1000,
+
+  spanning: true,
+
+  inclusive: false,
+
+  keepOnSplit: false,
+
+  exitable: true,
+
   addOptions() {
     return {
       HTMLAttributes: {},
+      activeClass: "is-active-comment",
+      hoveredClass: "is-hovered-comment",
       onCommentActivated: () => {},
+      onCommentSelectionChange: () => {},
     };
   },
 
@@ -45,9 +234,15 @@ export const CommentExtension = Mark.create<CommentOptions, CommentStorage>({
     return {
       commentId: {
         default: null,
-        parseHTML: (el) =>
-          (el as HTMLSpanElement).getAttribute("data-comment-id"),
-        renderHTML: (attrs) => ({ "data-comment-id": attrs.commentId }),
+        parseHTML: (element) =>
+          (element as HTMLSpanElement).getAttribute("data-comment-id"),
+        renderHTML: (attributes) => {
+          if (!attributes.commentId) {
+            return {};
+          }
+
+          return { "data-comment-id": attributes.commentId };
+        },
       },
     };
   },
@@ -56,8 +251,8 @@ export const CommentExtension = Mark.create<CommentOptions, CommentStorage>({
     return [
       {
         tag: "span[data-comment-id]",
-        getAttrs: (el) =>
-          !!(el as HTMLSpanElement).getAttribute("data-comment-id")?.trim() &&
+        getAttrs: (element) =>
+          !!(element as HTMLSpanElement).getAttribute("data-comment-id")?.trim() &&
           null,
       },
     ];
@@ -71,72 +266,244 @@ export const CommentExtension = Mark.create<CommentOptions, CommentStorage>({
     ];
   },
 
-  onSelectionUpdate() {
-    const { $from } = this.editor.state.selection;
-
-    const marks = $from.marks();
-
-    if (!marks.length) {
-      this.storage.activeCommentId = null;
-      this.options.onCommentActivated(this.storage.activeCommentId);
-      return;
-    }
-
-    const commentMark = this.editor.schema.marks.comment;
-
-    const activeCommentMark = marks.find((mark) => mark.type === commentMark);
-
-    this.storage.activeCommentId = activeCommentMark?.attrs.commentId || null;
-
-    this.options.onCommentActivated(this.storage.activeCommentId);
-  },
-
   addStorage() {
     return {
       activeCommentId: null,
+      activeCommentIds: [],
+      hoveredCommentId: null,
     };
+  },
+
+  onCreate() {
+    const pluginState = commentPluginKey.getState(this.editor.state);
+    const activeCommentIds = getSelectionCommentIds(
+      this.editor.state.doc,
+      this.editor.state.selection.from,
+      this.editor.state.selection.to,
+      this.editor.state.selection.empty,
+      this.editor.state.selection.$from.marks(),
+    );
+
+    this.storage.activeCommentIds = activeCommentIds;
+    this.storage.activeCommentId = activeCommentIds[0] || null;
+    this.storage.hoveredCommentId = pluginState?.hoveredCommentId || null;
+  },
+
+  onTransaction({ transaction }) {
+    const activeCommentIds = getSelectionCommentIds(
+      this.editor.state.doc,
+      this.editor.state.selection.from,
+      this.editor.state.selection.to,
+      this.editor.state.selection.empty,
+      this.editor.state.selection.$from.marks(),
+    );
+    const activeCommentId = activeCommentIds[0] || null;
+    const hoveredCommentId =
+      (transaction.getMeta(commentPluginKey) as CommentPluginMeta | undefined)
+        ?.hoveredCommentId ??
+      commentPluginKey.getState(this.editor.state)?.hoveredCommentId ??
+      null;
+    const shouldNotifyActiveId =
+      this.storage.activeCommentId !== activeCommentId;
+    const shouldNotifySelectionIds = !areStringArraysEqual(
+      this.storage.activeCommentIds,
+      activeCommentIds,
+    );
+
+    this.storage.activeCommentId = activeCommentId;
+    this.storage.activeCommentIds = activeCommentIds;
+    this.storage.hoveredCommentId = hoveredCommentId;
+
+    if (shouldNotifyActiveId) {
+      this.options.onCommentActivated(activeCommentId);
+    }
+
+    if (shouldNotifySelectionIds) {
+      this.options.onCommentSelectionChange(activeCommentIds);
+    }
   },
 
   addCommands() {
     return {
       setComment:
         (commentId) =>
-        ({ commands }) => {
-          if (!commentId) return false;
+        ({ state, dispatch }) => {
+          if (!commentId || state.selection.empty) {
+            return false;
+          }
 
-          commands.setMark("comment", { commentId });
+          const tr = state.tr;
+
+          tr.addMark(
+            state.selection.from,
+            state.selection.to,
+            this.type.create({ commentId }),
+          );
+          tr.removeStoredMark(this.type);
+
+          dispatch?.(tr);
+
+          return true;
         },
+
       unsetComment:
         (commentId) =>
-        ({ tr, dispatch }) => {
-          if (!commentId) return false;
+        ({ state, dispatch }) => {
+          const tr = state.tr;
 
-          const commentMarksWithRange: MarkWithRange[] = [];
-
-          tr.doc.descendants((node, pos) => {
-            const commentMark = node.marks.find(
-              (mark) =>
-                mark.type.name === "comment" &&
-                mark.attrs.commentId === commentId,
+          if (commentId) {
+            removeCommentRanges(
+              tr,
+              getCommentRanges(tr.doc, commentId),
+              this.type.create({ commentId }),
             );
+            dispatch?.(tr);
+            return true;
+          }
 
-            if (!commentMark) return;
+          if (!state.selection.empty) {
+            tr.removeMark(state.selection.from, state.selection.to, this.type);
+            dispatch?.(tr);
+            return true;
+          }
 
-            commentMarksWithRange.push({
-              mark: commentMark,
-              range: {
-                from: pos,
-                to: pos + node.nodeSize,
-              },
-            });
-          });
+          const activeCommentId = getSelectionCommentIds(
+            state.doc,
+            state.selection.from,
+            state.selection.to,
+            state.selection.empty,
+            state.selection.$from.marks(),
+          )[0];
 
-          commentMarksWithRange.forEach(({ mark, range }) => {
-            tr.removeMark(range.from, range.to, mark);
-          });
+          if (!activeCommentId) {
+            return false;
+          }
 
-          return dispatch?.(tr);
+          const activeRange = getCommentRanges(state.doc, activeCommentId).find(
+            (range) =>
+              state.selection.from >= range.from &&
+              state.selection.from <= range.to,
+          );
+
+          if (!activeRange) {
+            return false;
+          }
+
+          tr.removeMark(
+            activeRange.from,
+            activeRange.to,
+            this.type.create({ commentId: activeCommentId }),
+          );
+          dispatch?.(tr);
+
+          return true;
+        },
+
+      removeComment:
+        (commentId) =>
+        ({ state, dispatch }) => {
+          if (!commentId) {
+            return false;
+          }
+
+          const tr = state.tr;
+
+          removeCommentRanges(
+            tr,
+            getCommentRanges(tr.doc, commentId),
+            this.type.create({ commentId }),
+          );
+          dispatch?.(tr);
+
+          return true;
+        },
+
+      selectComment:
+        (commentId) =>
+        ({ state, dispatch }) => {
+          if (!commentId) {
+            return false;
+          }
+
+          const commentRange = getCommentRanges(state.doc, commentId)[0];
+
+          if (!commentRange) {
+            return false;
+          }
+
+          const tr = state.tr.setSelection(
+            TextSelection.create(state.doc, commentRange.from, commentRange.to),
+          );
+
+          dispatch?.(tr);
+
+          return true;
+        },
+
+      hoverComment:
+        (commentId) =>
+        ({ state, dispatch }) => {
+          const tr = state.tr;
+
+          tr.setMeta(commentPluginKey, {
+            hoveredCommentId: commentId,
+          } satisfies CommentPluginMeta);
+          tr.setMeta("addToHistory", false);
+
+          dispatch?.(tr);
+          this.storage.hoveredCommentId = commentId;
+
+          return true;
         },
     };
   },
+
+  addProseMirrorPlugins() {
+    const activeClass = this.options.activeClass;
+    const hoveredClass = this.options.hoveredClass;
+
+    return [
+      new Plugin<CommentPluginState>({
+        key: commentPluginKey,
+        state: {
+          init: (_, state) =>
+            createPluginState(
+              state.doc,
+              getSelectionCommentIds(
+                state.doc,
+                state.selection.from,
+                state.selection.to,
+                state.selection.empty,
+                state.selection.$from.marks(),
+              ),
+              null,
+              activeClass,
+              hoveredClass,
+            ),
+          apply: (tr, pluginState, _oldState, newState) => {
+            const meta = tr.getMeta(commentPluginKey) as CommentPluginMeta | undefined;
+
+            return createPluginState(
+              newState.doc,
+              getSelectionCommentIds(
+                newState.doc,
+                newState.selection.from,
+                newState.selection.to,
+                newState.selection.empty,
+                newState.selection.$from.marks(),
+              ),
+              meta?.hoveredCommentId ?? pluginState.hoveredCommentId,
+              activeClass,
+              hoveredClass,
+            );
+          },
+        },
+        props: {
+          decorations: (state) => commentPluginKey.getState(state)?.decorations,
+        },
+      }),
+    ];
+  },
 });
+
+export const Comment = CommentExtension;

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,4 @@
 export * from './comment';
 
+export { CommentExtension as Comment } from './comment'
 export { CommentExtension as default } from './comment'
-

--- a/tests/comment-extension.test.cjs
+++ b/tests/comment-extension.test.cjs
@@ -1,0 +1,311 @@
+const test = require("node:test");
+const assert = require("node:assert/strict");
+
+const { Editor, Mark, Node } = require("@tiptap/core");
+const extensionExports = require("../dist/index.cjs.js");
+
+const {
+  Comment,
+  CommentExtension,
+  commentPluginKey,
+  getCommentRanges,
+} = extensionExports;
+
+const Doc = Node.create({
+  name: "doc",
+  topNode: true,
+  content: "block+",
+});
+
+const Paragraph = Node.create({
+  name: "paragraph",
+  group: "block",
+  content: "inline*",
+  parseHTML() {
+    return [{ tag: "p" }];
+  },
+  renderHTML() {
+    return ["p", 0];
+  },
+});
+
+const Text = Node.create({
+  name: "text",
+  group: "inline",
+});
+
+const Bold = Mark.create({
+  name: "bold",
+  parseHTML() {
+    return [{ tag: "strong" }];
+  },
+  renderHTML() {
+    return ["strong", 0];
+  },
+});
+
+function createEditor({
+  content = {
+    type: "doc",
+    content: [
+      {
+        type: "paragraph",
+        content: [
+          {
+            type: "text",
+            text: "Hello",
+          },
+        ],
+      },
+    ],
+  },
+  commentOptions = {},
+} = {}) {
+  return new Editor({
+    extensions: [
+      Doc,
+      Paragraph,
+      Text,
+      Bold,
+      CommentExtension.configure(commentOptions),
+    ],
+    content,
+  });
+}
+
+function getCommentTexts(editor) {
+  const commentTexts = [];
+
+  editor.state.doc.descendants((node) => {
+    const commentMark = node.marks?.find((mark) => mark.type.name === "comment");
+
+    if (!commentMark) {
+      return;
+    }
+
+    commentTexts.push({
+      commentId: commentMark.attrs.commentId,
+      text: node.text || "",
+    });
+  });
+
+  return commentTexts;
+}
+
+test("exports a Comment alias and helper surface", () => {
+  assert.equal(Comment, CommentExtension);
+  assert.equal(typeof commentPluginKey.getState, "function");
+  assert.equal(typeof getCommentRanges, "function");
+});
+
+test("setComment returns true and inserted text after the mark stays unmarked", () => {
+  const editor = createEditor();
+
+  editor.commands.setTextSelection({ from: 1, to: 6 });
+
+  assert.equal(editor.commands.setComment("comment-1"), true);
+
+  editor.commands.setTextSelection(6);
+  assert.equal(editor.storage.comment.activeCommentId, null);
+
+  editor.commands.command(({ tr, dispatch }) => {
+    tr.insertText("!", 6);
+    dispatch?.(tr);
+    return true;
+  });
+
+  assert.deepEqual(getCommentTexts(editor), [
+    {
+      commentId: "comment-1",
+      text: "Hello",
+    },
+  ]);
+
+  const paragraph = editor.getJSON().content[0];
+  const lastNode = paragraph.content[1];
+
+  assert.equal(lastNode.text, "!");
+  assert.equal(lastNode.marks, undefined);
+
+  editor.destroy();
+});
+
+test("unsetComment without an id removes the active comment range", () => {
+  const editor = createEditor();
+
+  editor.commands.setTextSelection({ from: 1, to: 6 });
+  editor.commands.setComment("comment-1");
+
+  editor.commands.setTextSelection(3);
+
+  assert.equal(editor.commands.unsetComment(), true);
+  assert.deepEqual(getCommentTexts(editor), []);
+
+  editor.destroy();
+});
+
+test("removeComment removes every matching comment range across the document", () => {
+  const editor = createEditor({
+    content: {
+      type: "doc",
+      content: [
+        {
+          type: "paragraph",
+          content: [{ type: "text", text: "Hello" }],
+        },
+        {
+          type: "paragraph",
+          content: [{ type: "text", text: "World" }],
+        },
+      ],
+    },
+  });
+
+  editor.commands.setTextSelection({ from: 1, to: 6 });
+  editor.commands.setComment("shared");
+  editor.commands.setTextSelection({ from: 8, to: 13 });
+  editor.commands.setComment("shared");
+
+  assert.equal(editor.commands.removeComment("shared"), true);
+  assert.deepEqual(getCommentTexts(editor), []);
+
+  editor.destroy();
+});
+
+test("getCommentRanges groups adjacent text segments with the same comment id", () => {
+  const editor = createEditor({
+    content: {
+      type: "doc",
+      content: [
+        {
+          type: "paragraph",
+          content: [
+            {
+              type: "text",
+              text: "He",
+              marks: [{ type: "comment", attrs: { commentId: "comment-1" } }],
+            },
+            {
+              type: "text",
+              text: "ll",
+              marks: [
+                { type: "comment", attrs: { commentId: "comment-1" } },
+                { type: "bold" },
+              ],
+            },
+            {
+              type: "text",
+              text: "o",
+            },
+          ],
+        },
+      ],
+    },
+  });
+
+  assert.deepEqual(getCommentRanges(editor.state.doc), [
+    {
+      commentId: "comment-1",
+      from: 1,
+      to: 5,
+      text: "Hell",
+    },
+  ]);
+
+  editor.destroy();
+});
+
+test("selectComment focuses the first logical range for a comment id", () => {
+  const editor = createEditor({
+    content: {
+      type: "doc",
+      content: [
+        {
+          type: "paragraph",
+          content: [
+            {
+              type: "text",
+              text: "AB",
+              marks: [{ type: "comment", attrs: { commentId: "first" } }],
+            },
+            {
+              type: "text",
+              text: "CD",
+            },
+          ],
+        },
+        {
+          type: "paragraph",
+          content: [
+            {
+              type: "text",
+              text: "EF",
+              marks: [{ type: "comment", attrs: { commentId: "first" } }],
+            },
+          ],
+        },
+      ],
+    },
+  });
+
+  assert.equal(editor.commands.selectComment("first"), true);
+  assert.equal(editor.state.selection.from, 1);
+  assert.equal(editor.state.selection.to, 3);
+
+  editor.destroy();
+});
+
+test("hoverComment updates plugin and storage state", () => {
+  const editor = createEditor();
+
+  editor.commands.setTextSelection({ from: 1, to: 6 });
+  editor.commands.setComment("comment-1");
+
+  assert.equal(editor.commands.hoverComment("comment-1"), true);
+  assert.equal(editor.storage.comment.hoveredCommentId, "comment-1");
+
+  assert.equal(editor.commands.hoverComment(null), true);
+  assert.equal(editor.storage.comment.hoveredCommentId, null);
+
+  editor.destroy();
+});
+
+test("selection callbacks receive unique active ids and null-safe active id values", () => {
+  const activated = [];
+  const selected = [];
+  const editor = createEditor({
+    content: {
+      type: "doc",
+      content: [
+        {
+          type: "paragraph",
+          content: [
+            {
+              type: "text",
+              text: "AB",
+              marks: [{ type: "comment", attrs: { commentId: "comment-1" } }],
+            },
+            {
+              type: "text",
+              text: "CD",
+            },
+          ],
+        },
+      ],
+    },
+    commentOptions: {
+      onCommentActivated: (commentId) => activated.push(commentId),
+      onCommentSelectionChange: (commentIds) => selected.push(commentIds),
+    },
+  });
+
+  editor.commands.setTextSelection(2);
+  editor.commands.setTextSelection(4);
+
+  assert.equal(activated.at(-2), "comment-1");
+  assert.equal(activated.at(-1), null);
+  assert.deepEqual(selected.at(-2), ["comment-1"]);
+  assert.deepEqual(selected.at(-1), []);
+
+  editor.destroy();
+});


### PR DESCRIPTION
## Summary

This refactors the comment extension from a minimal mark wrapper into a more usable headless comment-anchor core.

## What changed

- add typed comment ranges, storage state, and exported helper surface
- add commands for removing, selecting, and hovering comments
- make comment application non-sticky so new typing and line breaks do not inherit the mark
- add decoration-backed active and hovered comment styling hooks
- add behavior tests for command semantics and range grouping
- align the README and React demo with the actual package API

## Why

The previous implementation had a few core limitations:

- `setComment` and `unsetComment` had weak command contracts
- active comment handling only tracked a single cursor-derived id
- there was no helper for grouping split comment ranges for sidebar UIs
- the documented and demoed API diverged from the package exports

## Validation

- `npm test`

## Notes

- this keeps the package as a lightweight mark-based comment anchor layer
- overlapping comments are still out of scope for this branch
